### PR TITLE
Open google-meet links in regular browser window when clicked on button in video.

### DIFF
--- a/src/main/features/externalLinks.ts
+++ b/src/main/features/externalLinks.ts
@@ -38,9 +38,11 @@ export default (window: BrowserWindow) => {
     const isGMailUrl = extractHostname(url) === 'mail.google.com' &&
       !url.startsWith('https://mail.google.com/chat')
 
+    const isGMeetUrl = extractHostname(url) === 'meet.google.com'
+
     const isNotWhitelistedHost = !whiteListedHosts.includes(extractHostname(url));
 
-    if (isGMailUrl || isDownloadUrl || isNotWhitelistedHost) {
+    if (isGMailUrl || isDownloadUrl || isNotWhitelistedHost || isGMeetUrl) {
 
       setImmediate(() => {
         shell.openExternal(url);


### PR DESCRIPTION
This one doesn't work because somehow it won't close the previous video element and not transfer the session to another window. Tried multiple ways with opening electron window, with providing window.parent attribute, but the problem still there. It's difficult to debug, so leave this PR as a starting point.